### PR TITLE
Calculate ignoring time and timezone values

### DIFF
--- a/holiday-de.js
+++ b/holiday-de.js
@@ -128,7 +128,7 @@
     var year = date.getFullYear();
     var tsYearStart = new Date(year, 0, 1).valueOf();
     var easterDays = Math.round((calculateEasterSunday(year).valueOf() - tsYearStart) / 86400000);
-    var diff = Math.round((date.valueOf() - tsYearStart) / 86400000) - easterDays;
+    var diff = Math.round((new Date(year, month, day).valueOf() - tsYearStart) / 86400000) - easterDays;
 
     function checkVar(name, d) {
       return exports.holidays[name] && diff === d ? name : false;

--- a/test/holiday-de.spec.js
+++ b/test/holiday-de.spec.js
@@ -100,6 +100,31 @@ describe('#holiday-de', function () {
     });
   });
 
+  describe('neglecting time and time zone', function () {
+    beforeEach(function () { holiday.setState('by'); });
+    afterEach(function () { holiday.resetHolidays(); });
+    it('isHoliday() should not identify holidays one second before they start', function () {
+      var test = holiday.isHoliday(new Date(2016, 4, 25, 23, 59, 59));
+      console.assert(test === false, '2016-05-25 23:59:59 should not be a holiday');
+    });
+    it('isHoliday() should identify holidays as soon as they start', function () {
+      var test = holiday.isHoliday(new Date(2016, 4, 26, 0, 0, 0));
+      console.assert(test, '2016-05-26 00:00:00 should be a holiday');
+    });
+    it('isHoliday() should identify holidays at noon', function () {
+      var test = holiday.isHoliday(new Date(2016, 4, 26, 12, 0, 0));
+      console.assert(test, '2016-05-26 12:00:00 should be a holiday');
+    });
+    it('isHoliday() should identify holidays one second before they are over', function () {
+      var test = holiday.isHoliday(new Date(2016, 4, 26, 23, 59, 59));
+      console.assert(test, '2016-05-26 23:59:59 should be a holiday');
+    });
+    it('isHoliday() should not identify holidays as soon as they are over', function () {
+      var test = holiday.isHoliday(new Date(2016, 4, 27, 0, 0, 0));
+      console.assert(test === false, '2016-05-27 00:00:00 should not be a holiday');
+    });
+  });
+
   describe('moment', function () {
     beforeEach(function () { holiday.setState('nw'); });
     it('isHoliday() should support a moment object', function () {


### PR DESCRIPTION
The calculation can yield incorrect results in case the time part of the input date is not 00:00:00. This PR should fix it.
